### PR TITLE
feat: stop recursing into sub directories if it contains `.skip-subtree`

### DIFF
--- a/buildTree.nix
+++ b/buildTree.nix
@@ -34,6 +34,7 @@ let
       dir = builtins.readDir path;
       dirFilter = name: type:
         type == "directory" &&
+        ! (builtins.hasAttr ".skip-subtree" dir) &&
         builtins.substring 0 1 name != "." # ignore folders starting with dot
       ;
       subDirs = filterAttrs dirFilter dir;


### PR DESCRIPTION
Save time on large/deep repositories