### PR TITLE
forward --show-trace to nix

### DIFF
--- a/bld.sh
+++ b/bld.sh
@@ -97,6 +97,10 @@ while [[ $# -gt 0 ]]; do
     cmd=interactive
     shift
     ;;
+  --show-trace)
+    nix_opts+=(--show-trace)
+    shift
+    ;;
   --)
     break
     ;;


### PR DESCRIPTION
It's confusing when the nix output specifies --show-trace and then it's
not available.
