### PR TITLE
fix: build output

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -7,8 +7,9 @@ import (
 )
 
 type Build struct {
-	Target    string `arg:"" name:"target" help:"Target to build" type:"target"`
-	ShowTrace bool   `name:"show-trace" help:"Show trace on error"`
+	Target     string `arg:"" name:"target" help:"Target to build" type:"target"`
+	ShowTrace  bool   `name:"show-trace" help:"Show trace on error"`
+	JSONOutput bool   `name:"json" help:"Return json formatted output"`
 }
 
 func (b *Build) Run(_ *kong.Context) error {
@@ -21,7 +22,7 @@ func (b *Build) Run(_ *kong.Context) error {
 		return err
 	}
 
-	err = nix.Build(rootDirectory, b.Target, b.ShowTrace)
+	err = nix.Build(rootDirectory, b.Target, b.ShowTrace, b.JSONOutput)
 	if err != nil {
 		return err
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -25,7 +25,7 @@ func (r *Run) Run(_ *kong.Context) error {
 		return err
 	}
 
-	err = nix.Build(rootDirectory, r.Target, r.ShowTrace)
+	err = nix.Build(rootDirectory, r.Target, r.ShowTrace, false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Print build output as text or json.
Use same default as nix build.
